### PR TITLE
Removed boilerplate for adding widgets

### DIFF
--- a/resources/js/components/App.vue
+++ b/resources/js/components/App.vue
@@ -19,13 +19,6 @@
                             >
                                 Dashboard
                             </router-link>
-                            <router-link
-                                to="/widgets"
-                                class="inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium leading-5 transition"
-                                :class="[$route.name === 'widgets' ? 'border-primary-500 text-dark-900 dark:text-dark-100' : 'border-transparent text-dark-500 dark:text-dark-300 hover:text-dark-700 dark:hover:text-dark-200 hover:border-dark-300 dark:hover:border-dark-700']"
-                            >
-                                Widgets
-                            </router-link>
                         </div>
                     </div>
 
@@ -63,14 +56,6 @@
                         @click="mobileMenuOpen = false"
                     >
                         Dashboard
-                    </router-link>
-                    <router-link
-                        to="/widgets"
-                        class="block pl-3 pr-4 py-2 border-l-4 text-base font-medium transition"
-                        :class="[$route.name === 'widgets' ? 'border-primary-500 text-primary-700 dark:text-primary-300 bg-primary-50 dark:bg-primary-900/20' : 'border-transparent text-dark-600 dark:text-dark-400 hover:text-dark-800 dark:hover:text-dark-200 hover:bg-dark-50 dark:hover:bg-dark-700 hover:border-dark-300 dark:hover:border-dark-600']"
-                        @click="mobileMenuOpen = false"
-                    >
-                        Widgets
                     </router-link>
                 </div>
             </div>

--- a/resources/js/router/index.ts
+++ b/resources/js/router/index.ts
@@ -1,6 +1,5 @@
 import { createRouter, createWebHistory, RouteRecordRaw } from 'vue-router';
 import Dashboard from '../views/Dashboard.vue';
-import WidgetManager from '../views/WidgetManager.vue';
 import NotFound from '../views/NotFound.vue';
 
 const routes: Array<RouteRecordRaw> = [
@@ -9,12 +8,6 @@ const routes: Array<RouteRecordRaw> = [
     name: 'dashboard',
     component: Dashboard,
     meta: { title: 'Dashboard' }
-  },
-  {
-    path: '/widgets',
-    name: 'widgets',
-    component: WidgetManager,
-    meta: { title: 'Widget Manager' }
   },
   {
     path: '/:pathMatch(.*)*',

--- a/resources/js/views/Dashboard.vue
+++ b/resources/js/views/Dashboard.vue
@@ -128,17 +128,6 @@
           </div>
         </div>
 
-        <!-- Add Widget Button -->
-        <div class="bg-white dark:bg-dark-800 overflow-hidden shadow-md rounded-lg border-2 border-dashed border-dark-300 dark:border-dark-600">
-          <div class="p-6 flex items-center justify-center">
-            <router-link to="/widgets" class="text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-300 flex items-center">
-              <svg class="w-6 h-6 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
-              </svg>
-              <span class="text-lg font-medium">Add Widget</span>
-            </router-link>
-          </div>
-        </div>
       </template>
     </div>
   </div>


### PR DESCRIPTION
As part of the initial build, I generated some boilerplate so that there was a widget management page in the UI to add widgets. As i'll be building these and controlling them solely in the code, we can remove the boilerplate.